### PR TITLE
Modify Type of TotalPaidMinutesUsed

### DIFF
--- a/pkg/server/collector.go
+++ b/pkg/server/collector.go
@@ -94,9 +94,9 @@ var (
 )
 
 type actionsBilling struct {
-	TotalMinutesUsed     int `json:"total_minutes_used"`
+	TotalMinutesUsed     int         `json:"total_minutes_used"`
 	TotalPaidMinutesUsed json.Number `json:"total_paid_minutes_used"`
-	IncludedMinutes      int `json:"included_minutes"`
+	IncludedMinutes      int         `json:"included_minutes"`
 	MinutesUsedBreakdown struct {
 		UBUNTU  int `json:"UBUNTU"`
 		MACOS   int `json:"MACOS"`

--- a/pkg/server/collector.go
+++ b/pkg/server/collector.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -96,7 +95,7 @@ var (
 
 type actionsBilling struct {
 	TotalMinutesUsed     int    `json:"total_minutes_used"`
-	TotalPaidMinutesUsed string `json:"total_paid_minutes_used"`
+	TotalPaidMinutesUsed int `json:"total_paid_minutes_used"`
 	IncludedMinutes      int    `json:"included_minutes"`
 	MinutesUsedBreakdown struct {
 		UBUNTU  int `json:"UBUNTU"`
@@ -169,13 +168,8 @@ func getGitHubActionsBilling(mode apiMode, args *Args) {
 		}
 		resp.Body.Close()
 
-		f, err := strconv.ParseFloat(p.TotalPaidMinutesUsed, 64)
-		if err != nil {
-			log.Fatal(err)
-		}
-
 		totalMinutesUsedGauge.WithLabelValues(owner).Set(float64(p.TotalMinutesUsed))
-		totalPaidMinutesUsedGauge.WithLabelValues(owner).Set(f)
+		totalPaidMinutesUsedGauge.WithLabelValues(owner).Set(float64(p.TotalPaidMinutesUsed))
 		includedMinutesGauge.WithLabelValues(owner).Set(float64(p.IncludedMinutes))
 		minutesUsedBreakdownGauge.WithLabelValues(owner, "ubuntu").Set(float64(p.MinutesUsedBreakdown.UBUNTU))
 		minutesUsedBreakdownGauge.WithLabelValues(owner, "macos").Set(float64(p.MinutesUsedBreakdown.MACOS))

--- a/pkg/server/collector.go
+++ b/pkg/server/collector.go
@@ -95,7 +95,7 @@ var (
 
 type actionsBilling struct {
 	TotalMinutesUsed     int `json:"total_minutes_used"`
-	TotalPaidMinutesUsed int `json:"total_paid_minutes_used"`
+	TotalPaidMinutesUsed json.Number `json:"total_paid_minutes_used"`
 	IncludedMinutes      int `json:"included_minutes"`
 	MinutesUsedBreakdown struct {
 		UBUNTU  int `json:"UBUNTU"`
@@ -168,8 +168,13 @@ func getGitHubActionsBilling(mode apiMode, args *Args) {
 		}
 		resp.Body.Close()
 
+		f, err := p.TotalPaidMinutesUsed.Float64()
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		totalMinutesUsedGauge.WithLabelValues(owner).Set(float64(p.TotalMinutesUsed))
-		totalPaidMinutesUsedGauge.WithLabelValues(owner).Set(float64(p.TotalPaidMinutesUsed))
+		totalPaidMinutesUsedGauge.WithLabelValues(owner).Set(f)
 		includedMinutesGauge.WithLabelValues(owner).Set(float64(p.IncludedMinutes))
 		minutesUsedBreakdownGauge.WithLabelValues(owner, "ubuntu").Set(float64(p.MinutesUsedBreakdown.UBUNTU))
 		minutesUsedBreakdownGauge.WithLabelValues(owner, "macos").Set(float64(p.MinutesUsedBreakdown.MACOS))

--- a/pkg/server/collector.go
+++ b/pkg/server/collector.go
@@ -94,9 +94,9 @@ var (
 )
 
 type actionsBilling struct {
-	TotalMinutesUsed     int    `json:"total_minutes_used"`
+	TotalMinutesUsed     int `json:"total_minutes_used"`
 	TotalPaidMinutesUsed int `json:"total_paid_minutes_used"`
-	IncludedMinutes      int    `json:"included_minutes"`
+	IncludedMinutes      int `json:"included_minutes"`
 	MinutesUsedBreakdown struct {
 		UBUNTU  int `json:"UBUNTU"`
 		MACOS   int `json:"MACOS"`


### PR DESCRIPTION
## Problem
I got error when I use gihub-billing-exporter.
The error message is as follows.

```
$ ./github-billing-expoerter server -t MY_TOKEN -o MY_ORGS
2021/03/04 19:39:50 json: cannot unmarshal number into Go struct field actionsBilling.total_paid_minutes_used of type string
```

The problem is that when the return value of total_paid_minutes_used is 0, as shown below, Golang Interprets it as Integer
Maybe, if the return value is non-zero, then strconvParseFloat will convert the value to Float64.

```
% curl -k -s -u ruchikawa:MASKED  'https://api.github.com/orgs/masked/settings/billing/actions'
{
  "total_minutes_used": 2403,
  "total_paid_minutes_used": 0,
  "included_minutes": 3000,
  "minutes_used_breakdown": {
    "UBUNTU": 2403
  }
}
```

## Solution
The reason is that the return value of `total_paid_minutes_used` will return a number of minutes, so I thought the type should be an integer.
If total_paid_minutes_used returns a non-integer value, this fix is not appropriate.
But I coudn't check the return of value, because Our organization returns `total_paid_minutes_used` as 0.



## Before & After
I did not have time to write the test.
```
# before
% go run main.go server -t MY_TOKEN -o MY_ORGS
2021/03/04 22:25:29 json: cannot unmarshal number into Go struct field actionsBilling.total_paid_minutes_used of type string
exit status 1
```


```
# After
## run gihub-billing-exporter
% go run main.go server -t MY_TOKEN -o MY_ORGS

##  curl with Another terminal
% curl localhost:9999/metrics | grep total_paid_minutes_used
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  6985    0  6985    0     0  6821k      0 --:--:-- --:--:-- --:--:-- 6821k
# HELP total_paid_minutes_used github actions total paid minutes used
# TYPE total_paid_minutes_used gauge
total_paid_minutes_used{owner="MY_OWNER"} 0
``